### PR TITLE
Feat/pages and navigation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ export default function Home() {
   return (
     <div className="mx-auto max-w-md p-6 space-y-6">
       <header className="text-center space-y-1">
-        <h1 className="text-2xl font-semibold">Beatles Quiz & Trivia</h1>
+        <h1 className="text-2xl font-bold">Beatles Quiz & Trivia</h1>
         <p className="text-sm text-gray-600">
           Guess the album name from the cover art
         </p>
@@ -68,7 +68,7 @@ export default function Home() {
 //         <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
 //           <li className="mb-2 tracking-[-.01em]">
 //             Get started by editing{" "}
-//             <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
+//             <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-bold px-1 py-0.5 rounded">
 //               src/app/page.tsx
 //             </code>
 //             .

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,154 @@
-import Image from "next/image";
+"use client";
+
+import Link from "next/link";
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+    <div className="mx-auto max-w-md p-6 space-y-6">
+      <header className="text-center space-y-1">
+        <h1 className="text-2xl font-semibold">Beatles Quiz & Trivia</h1>
+        <p className="text-sm text-gray-600">
+          Guess the album name from the cover art
+        </p>
+      </header>
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
+      {/* no form validation for now */}
+      <form className="space-y-4" noValidate>
+        <div>
+          <label htmlFor="name" className="block text-sm font-medium">
+            Your name
+          </label>
+          <input
+            id="name"
+            name="name"
+            placeholder="e.g. Simon"
+            className="mt-1 w-full rounded border px-3 py-2"
+          />
         </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
+
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium">
+            Email
+          </label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="you@example.com"
+            className="mt-1 w-full rounded border px-3 py-2"
           />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
+        </div>
+
+        {/* not validating yet, just nav-ing from page to page */}
+        <Link
+          href="/quiz"
+          className="block w-full text-center rounded bg-white px-4 py-2 font-medium text-black"
         >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+          Start Quiz
+        </Link>
+      </form>
     </div>
   );
 }
+
+//////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////
+
+//  <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
+//       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
+//         <Image
+//           src={`/api/beatles/${id}`}
+//           alt={`Album cover ${id}`}
+//           width={300}
+//           height={300}
+//           priority
+//         />
+//         <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
+//           <li className="mb-2 tracking-[-.01em]">
+//             Get started by editing{" "}
+//             <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
+//               src/app/page.tsx
+//             </code>
+//             .
+//           </li>
+//           <li className="tracking-[-.01em]">
+//             Save and see your changes instantly.
+//           </li>
+//         </ol>
+
+//         <div className="flex gap-4 items-center flex-col sm:flex-row">
+//           <a
+//             className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
+//             href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
+//             target="_blank"
+//             rel="noopener noreferrer"
+//           >
+//             <Image
+//               className="dark:invert"
+//               src="/vercel.svg"
+//               alt="Vercel logomark"
+//               width={20}
+//               height={20}
+//             />
+//             Deploy now
+//           </a>
+//           <a
+//             className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
+//             href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
+//             target="_blank"
+//             rel="noopener noreferrer"
+//           >
+//             Read our docs
+//           </a>
+//         </div>
+//       </main>
+//       <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
+//         <a
+//           className="flex items-center gap-2 hover:underline hover:underline-offset-4"
+//           href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
+//           target="_blank"
+//           rel="noopener noreferrer"
+//         >
+//           <Image
+//             aria-hidden
+//             src="/file.svg"
+//             alt="File icon"
+//             width={16}
+//             height={16}
+//           />
+//           Learn
+//         </a>
+//         <a
+//           className="flex items-center gap-2 hover:underline hover:underline-offset-4"
+//           href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
+//           target="_blank"
+//           rel="noopener noreferrer"
+//         >
+//           <Image
+//             aria-hidden
+//             src="/window.svg"
+//             alt="Window icon"
+//             width={16}
+//             height={16}
+//           />
+//           Examples
+//         </a>
+//         <a
+//           className="flex items-center gap-2 hover:underline hover:underline-offset-4"
+//           href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
+//           target="_blank"
+//           rel="noopener noreferrer"
+//         >
+//           <Image
+//             aria-hidden
+//             src="/globe.svg"
+//             alt="Globe icon"
+//             width={16}
+//             height={16}
+//           />
+//           Go to nextjs.org →
+//         </a>
+//       </footer>
+//     </div>

--- a/src/app/quiz/error.tsx
+++ b/src/app/quiz/error.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export default function Error({ error }: { error: Error }) {
+  return (
+    <main className="mx-auto max-w-lg p-6 space-y-2">
+      <h1 className="text-xl font-bold">Something went wrong</h1>
+      <p className="text-sm text-red-600">{error.message}</p>
+    </main>
+  );
+}

--- a/src/app/quiz/loading.tsx
+++ b/src/app/quiz/loading.tsx
@@ -1,0 +1,7 @@
+export default function QuizLoading() {
+  return (
+    <main className="mx-auto max-w-lg p-6">
+      <p>Loading quiz question</p>
+    </main>
+  );
+}

--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -17,7 +17,7 @@ export default function QuizPage() {
 
       <div className="space-y-2">
         <button className="w-full rounded border px-3 py-2 text-left hover:bg-gray-50">
-          Option 1: Album Name here
+          Option 1: Album Name
         </button>
         <button className="w-full rounded border px-3 py-2 text-left hover:bg-gray-50">
           Option 2: album Name

--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+
+export default function QuizPage() {
+  return (
+    <div className="mx-auto max-w-lg p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold">Question 1 of 5</h1>
+        <span className="text-sm text-gray-600">Score: 0</span>
+      </div>
+
+      {/* blank spot for where image will go */}
+      <div className="rounded border p-4 flex items-center justify-center h-72">
+        <div className="text-gray-500"> album art will go here</div>
+      </div>
+
+      <div className="space-y-2">
+        <button className="w-full rounded border px-3 py-2 text-left hover:bg-gray-50">
+          Option 1: Album Name here
+        </button>
+        <button className="w-full rounded border px-3 py-2 text-left hover:bg-gray-50">
+          Option 2: album Name
+        </button>
+        <button className="w-full rounded border px-3 py-2 text-left hover:bg-gray-50">
+          Option 3: Album Name
+        </button>
+      </div>
+
+      <div className="flex items-center justify-end">
+        {/* for now, allow jumping to results without checkibg answer was given */}
+        <Link href="/results" className="rounded bg-black px-4 py-2 text-white">
+          Exit Quiz
+        </Link>
+        <button className="rounded px-4 py-2 border">Next</button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/results/page.tsx
+++ b/src/app/results/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+
+export default function ResultsPage() {
+  return (
+    <div className="mx-auto max-w-lg p-6 space-y-6">
+      <header className="text-center space-y-1">
+        <h1 className="text-2xl font-semibold">Your Results</h1>
+        <p className="text-sm text-gray-600">Nice run!</p>
+      </header>
+
+      <div className="rounded border p-4 space-y-2">
+        <p>
+          <strong>Score:</strong> 3 / 5
+        </p>
+        <p>
+          <strong>Accuracy:</strong> 60%
+        </p>
+      </div>
+
+      <div className="flex gap-3">
+        <Link href="/" className="rounded bg-black px-4 py-2 text-white">
+          Exit
+        </Link>
+        <Link href="/quiz" className="rounded border px-4 py-2">
+          Play Again
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Implemented the visual elements of the three basic pages, no business logic or validation yet, only static HTML and basic tailwind styling.
Navigation between pages, for now, is just via button click without validation. Programmatic navigating & validation will come later with business logic.

- Welcome/start page (collect info form and start quiz)
- Quiz page (where album image, options and trivia will be populated)
- Results page (display results & option to exit or replay)

PS - Quiz Page also includes nextjs loading-state & error-boundary components, as this page will be fetching from the Beatles API and hence has the potential to encounter slow loading time and/or errors.


<img width="994" height="679" alt="image" src="https://github.com/user-attachments/assets/44aacb8c-dc13-49ec-b412-3b7d3d612d1d" />
<img width="988" height="675" alt="image" src="https://github.com/user-attachments/assets/41e7abaf-4671-4677-8545-483e6a0e7da4" />
<img width="988" height="678" alt="image" src="https://github.com/user-attachments/assets/36495584-4e81-4ddf-bc75-71e203a0f813" />
<img width="988" height="675" alt="image" src="https://github.com/user-attachments/assets/762f7213-604a-486c-ae4e-29790badcdd7" />
<img width="995" height="685" alt="image" src="https://github.com/user-attachments/assets/8effeed0-affc-4231-b795-1b2df3596ab9" />
