### PR TITLE
Feat/session info saving

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { setItem } from "@/lib/storageHelpers";
 
 interface PlayerINfoForm {
   name: string;
@@ -41,15 +42,11 @@ const Home = () => {
     const playerInfo = {
       name: form.name.trim(),
       email: form.email.trim(),
-      roundsplayed: 0,
-      guessesMade: 0,
-      correctGuesses: 0,
     };
-    const playerInfoJSON = JSON.stringify(playerInfo);
-    sessionStorage.setItem("player", playerInfoJSON);
 
+    setItem("playerName", playerInfo.name);
+    setItem("playerEmail", playerInfo.email);
     console.log("playerInfo: ,", playerInfo);
-
     router.push("/quiz");
   };
 

--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { albumNamesHardcoded, albumTrivia } from "@/lib/albumInfo";
+import { setItem, getItem } from "@/lib/storageHelpers";
 
 const randomNumber = (min: number, max: number) =>
   Math.floor(Math.random() * (max - min + 1)) + min;
@@ -66,6 +67,9 @@ const QuizPage = () => {
   const [isFlipped, setIsFlipped] = useState<boolean>(false); // card flipping
   const [wrongId, setWrongId] = useState<number | null>(null); // id of incorrectly chosen option so it knows which one to do shake and flash effect
 
+  const guessesMade = getItem("guessesMade") ?? 0;
+  const roundsPlayed = getItem("roundsPlayed") ?? 0;
+
   const currentQuestion = questions[currentQuestionIndex];
 
   const handleCardFlip = () => {
@@ -73,7 +77,17 @@ const QuizPage = () => {
   };
 
   const onSelect = (albumId: number) => {
-    if (albumId === currentQuestion.correctAlbumId) {
+    const isCorrect = albumId === currentQuestion.correctAlbumId;
+
+    // increment TOTAL guesses
+    const guesses = (getItem("guessesMade") ?? 0) + 1;
+    setItem("guessesMade", guesses);
+
+    if (isCorrect) {
+      // increment correct guesses
+      const corrects = (getItem("correctGuesses") ?? 0) + 1;
+      setItem("correctGuesses", corrects);
+
       setSelectedId(albumId);
       setWrongId(null);
       handleCardFlip();
@@ -92,6 +106,10 @@ const QuizPage = () => {
         setSelectedId(null);
       }, 700);
     } else {
+      // increment roundsPlayed
+      const rounds = (getItem("roundsPlayed") ?? 0) + 1;
+      setItem("roundsPlayed", rounds);
+
       setTimeout(() => {
         router.push("/results");
       }, 700);
@@ -104,7 +122,10 @@ const QuizPage = () => {
         <h1 className="text-xl font-bold">
           Question {currentQuestionIndex + 1} of {5}
         </h1>
-        <span className="text-sm text-gray-600">Guesses made: 696</span>
+        <span className="text-sm text-gray-600">
+          Round: {roundsPlayed + 1} | Guesses: {guessesMade}
+        </span>
+        <span className="text-sm text-gray-600"></span>
       </div>
 
       <div className="rounded p-4 flex items-center justify-center h-72">
@@ -170,7 +191,7 @@ const QuizPage = () => {
           disabled={selectedId == null}
           className="rounded bg-white px-4 py-2 font-medium text-black cursor-pointer hover:bg-gray-300 disabled:cursor-not-allowed"
         >
-          {currentQuestionIndex < 5 - 1 ? "Next" : "See Results"}
+          {currentQuestionIndex < 5 - 1 ? "Next" : "See stats"}
         </button>
       </div>
     </div>

--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { albumNamesHardcoded, albumTrivia } from "@/lib/albumInfo";
@@ -69,6 +69,7 @@ const QuizPage = () => {
 
   const guessesMade = getItem("guessesMade") ?? 0;
   const roundsPlayed = getItem("roundsPlayed") ?? 0;
+  const playerName = getItem("playerName") ?? "";
 
   const currentQuestion = questions[currentQuestionIndex];
 
@@ -115,6 +116,10 @@ const QuizPage = () => {
       }, 700);
     }
   };
+
+  useEffect(() => {
+    if (!playerName) router.push("/");
+  }, [playerName, router]);
 
   return (
     <div className="mx-auto max-w-lg p-6 space-y-6">

--- a/src/app/results/page.tsx
+++ b/src/app/results/page.tsx
@@ -17,11 +17,14 @@ const ResultsPage = () => {
         </p>
       </div>
 
-      <div className="flex gap-3">
+      <div className="flex items-center justify-end gap-3">
         <Link href="/" className="rounded bg-black px-4 py-2 text-white">
           Exit
         </Link>
-        <Link href="/quiz" className="rounded border px-4 py-2">
+        <Link
+          href="/quiz"
+          className="rounded bg-white px-4 py-2 font-medium text-black cursor-pointer hover:bg-gray-300 "
+        >
           Play Again
         </Link>
       </div>

--- a/src/app/results/page.tsx
+++ b/src/app/results/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { getItem, clearAll } from "@/lib/storageHelpers";
 import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 const ResultsPage = () => {
   const router = useRouter();
@@ -11,6 +12,10 @@ const ResultsPage = () => {
   const guessesMade = getItem("guessesMade") ?? 0;
   const correctGuesses = getItem("correctGuesses") ?? 0;
   const playerName = getItem("playerName") ?? "Player";
+
+  useEffect(() => {
+    if (!playerName) router.push("/");
+  }, [playerName, router]);
 
   return (
     <div className="mx-auto max-w-lg p-6 space-y-6">

--- a/src/app/results/page.tsx
+++ b/src/app/results/page.tsx
@@ -1,26 +1,50 @@
+"use client";
+
 import Link from "next/link";
+import { getItem, clearAll } from "@/lib/storageHelpers";
+import { useRouter } from "next/navigation";
 
 const ResultsPage = () => {
+  const router = useRouter();
+
+  const roundsPlayed = getItem("roundsPlayed") ?? 0;
+  const guessesMade = getItem("guessesMade") ?? 0;
+  const correctGuesses = getItem("correctGuesses") ?? 0;
+  const playerName = getItem("playerName") ?? "Player";
+
   return (
     <div className="mx-auto max-w-lg p-6 space-y-6">
       <header className="text-center space-y-1">
-        <h1 className="text-2xl font-semibold">Your Results</h1>
-        <p className="text-sm text-gray-600">Nice run!</p>
+        <h1 className="text-2xl font-semibold">Your Stats</h1>
+        <p className="text-sm text-gray-600">Nice run, {playerName}!</p>
       </header>
 
       <div className="rounded border p-4 space-y-2">
         <p>
-          <strong>Score:</strong> 3 / 5
+          <strong>Rounds played:</strong> {roundsPlayed}
         </p>
         <p>
-          <strong>Accuracy:</strong> 60%
+          <strong>Total guesses:</strong> {guessesMade}
+        </p>
+        <p>
+          <strong>Total correct guesses:</strong> {correctGuesses}
+        </p>
+        <p>
+          <strong>Accuracy:</strong>{" "}
+          {((correctGuesses / guessesMade) * 100).toFixed(1)}%
         </p>
       </div>
 
       <div className="flex items-center justify-end gap-3">
-        <Link href="/" className="rounded bg-black px-4 py-2 text-white">
+        <button
+          onClick={() => {
+            clearAll();
+            router.push("/");
+          }}
+          className="rounded bg-black px-4 py-2 text-white cursor-pointer hover:bg-gray-800 "
+        >
           Exit
-        </Link>
+        </button>
         <Link
           href="/quiz"
           className="rounded bg-white px-4 py-2 font-medium text-black cursor-pointer hover:bg-gray-300 "

--- a/src/lib/storageHelpers.ts
+++ b/src/lib/storageHelpers.ts
@@ -1,0 +1,9 @@
+export const setItem = (key: string, value: any) =>
+  sessionStorage.setItem(key, JSON.stringify(value));
+
+export const getItem = (key: string) => {
+  const raw = sessionStorage.getItem(key);
+  return raw ? JSON.parse(raw) : null;
+};
+
+export const clearAll = () => sessionStorage.clear();


### PR DESCRIPTION
Created logic to save and fetch user & quiz data, finalised all business logic
- using sessionStorage instead of localStorage because doesn't feel necessary to persist even after browser close
- Created helper functions to save to & fetch from sessionStorage
- incremented total guesses, correct guesses, and rounds played
- displayed cumulative stats on results screen
- displayed current round and total guesses on quiz screen
- force user back to welcome screen if no user info is found in sessionStorage
- 'play again' button keeps info, whilst 'exit' button dumps all data and routes back to welcome screen


![welcome page gif](https://github.com/user-attachments/assets/5ea59266-4854-4850-a451-29b2c2b60b92)
![quiz questions gif](https://github.com/user-attachments/assets/a5e8863e-9ff2-49ed-abf1-c80be6b99b5f)
![results screen gif](https://github.com/user-attachments/assets/e0c5e579-107c-4d0f-8c87-36f69c25111f)
